### PR TITLE
Fix compiler warning on boost::filesystem::path::leaf()

### DIFF
--- a/src/utils/files.cpp
+++ b/src/utils/files.cpp
@@ -44,11 +44,11 @@ bool directoryExists(const std::string& path)
     return boost::filesystem::exists(path) && boost::filesystem::is_directory(path);
 }
 
-struct path_leaf_string
+struct path_filename_string
 {
     std::string operator()(const boost::filesystem::directory_entry& entry) const
     {
-        return entry.path().leaf().string();
+        return entry.path().filename().string();
     }
 };
 
@@ -59,7 +59,7 @@ std::vector<std::string> getFilesInDirectory(const std::string& path)
     boost::filesystem::path p(path);
     boost::filesystem::directory_iterator start(p);
     boost::filesystem::directory_iterator end;
-    std::transform(start, end, std::back_inserter(tmp), path_leaf_string());
+    std::transform(start, end, std::back_inserter(tmp), path_filename_string());
 
     return tmp;
 }


### PR DESCRIPTION
This fixes the following compiler warning:

```
src/utils/files.cpp:
  In member function ‘std::string jASTERIX::Files::path_leaf_string::operator()(const boost::filesystem::directory_entry&) const’:
src/utils/files.cpp:51:33:
  warning: ‘boost::filesystem::path boost::filesystem::path::leaf() const’ is deprecated:
  Use path::filename() instead [-Wdeprecated-declarations]
   51 |         return entry.path().leaf().string();
      |                ~~~~~~~~~~~~~~~~~^~
```