### PR TITLE
Fix CMake version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(JASTERIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 message("  Path: ${JASTERIX_PATH}")
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.3...4.1)
 set ( CMAKE_BUILD_TYPE RelWithDebInfo ) #Debug RelWithDebInfo Release
 
 project( jASTERIX )


### PR DESCRIPTION
This fixes the following error message on modern CMake versions:

```
CMake Error at CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
